### PR TITLE
Consolidate items and item count into DataGridResult object

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ public class WeatherForecastService : IDataGridService<WeatherForecast>
     // This should be replaced with your actual data source
     private readonly List<WeatherForecast> Data = new List<WeatherForecast>();
 
-    public async Task<List<WeatherForecast>> GetItemsAsync(
+    public async Task<DataGridResult<WeatherForecast>> GetItemsAsync(
         int pageNumber,
         int pageSize,
         SortInformation<WeatherForecast> sortInfo = null,
@@ -64,31 +64,15 @@ public class WeatherForecastService : IDataGridService<WeatherForecast>
             // Add logic for parameter handling here
         }
 
+        // Get total item count before performing pagination
+        var totalItems = (uint)query.Count();
+
         // Logic for pagination
         var items = query.Skip((pageNumber - 1) * pageSize)
             .Take(pageSize)
             .ToList();
 
-        return items;
-    }
-
-    public async Task<int> GetItemCountAsync(
-        string searchQuery = null,
-        object parameters = null)
-    {
-        var query = Data.AsQueryable();
-
-        if (!(searchQuery is null))
-        {
-            // Add logic for search queries here
-        }
-
-        if (!(parameters is null))
-        {
-            // Add logic for parameter handling here
-        }
-
-        return query.Count();
+        return new DataGridResult<WeatherForecast>(items, totalItems);
     }
 }
 ```

--- a/src/Pyrox.BlazorComponents.DataGrid/DataGrid.razor
+++ b/src/Pyrox.BlazorComponents.DataGrid/DataGrid.razor
@@ -44,21 +44,21 @@
         </BSTableRow>
     </BSTableHead>
     <BSTableBody>
-        @if (items is null || isLoading)
+        @if (result is null || isLoading)
         {
             <tr>
-                <td colspan="@(Enum.GetNames(typeof(TItem)).Count())">Loading...</td>
+                <td colspan="@(typeof(TItem).GetProperties().Length)">Loading...</td>
             </tr>
         }
-        else if (items.Count == 0)
+        else if (result.TotalItems == 0)
         {
             <tr>
-                <td colspan="@(Enum.GetNames(typeof(TItem)).Count())">No data</td>
+                <td colspan="@(typeof(TItem).GetProperties().Length)">No data</td>
             </tr>
         }
         else
         {
-            foreach (var data in items)
+            foreach (var data in result.Data)
             {
                 <tr>
                     @GridRow(data)
@@ -68,12 +68,11 @@
     </BSTableBody>
 </BSTable>
 
-@if (!(totalItems is null))
+@if (!(result is null))
 {
     <PaginationControls @ref="paginationControls"
-                        TotalItems="(int)totalItems"
+                        TotalItems="(int)result.TotalItems"
                         StartPage="1"
                         ItemsPerPage="currentItemsPerPage"
                         OnPageChange="HandlePageChange" />
 }
-

--- a/src/Pyrox.BlazorComponents.DataGrid/DataGrid.razor.cs
+++ b/src/Pyrox.BlazorComponents.DataGrid/DataGrid.razor.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Pyrox.BlazorComponents.DataGrid.Components;
 using Pyrox.BlazorComponents.DataGrid.Interfaces;
-using System.Collections.Generic;
+using Pyrox.BlazorComponents.DataGrid.Models;
 using System.Threading.Tasks;
 
 namespace Pyrox.BlazorComponents.DataGrid
@@ -10,8 +10,7 @@ namespace Pyrox.BlazorComponents.DataGrid
     {
         [Inject] public IDataGridService<TItem> DataService { get; set; }
 
-        protected List<TItem> items;
-        protected int? totalItems;
+        protected DataGridResult<TItem> result;
         protected bool isLoading = false;
         protected bool isSaving = false;
 
@@ -48,18 +47,14 @@ namespace Pyrox.BlazorComponents.DataGrid
 
         protected override async Task OnInitializedAsync()
         {
-            await Task.WhenAll(new[]
-            {
-                GetItems(),
-                GetItemCount()
-            });
+            await GetItems();
         }
 
         private async Task GetItems()
         {
             isLoading = true;
 
-            items = await DataService.GetItemsAsync(
+            result = await DataService.GetItemsAsync(
                 currentPage,
                 currentItemsPerPage,
                 currentSort,
@@ -67,12 +62,6 @@ namespace Pyrox.BlazorComponents.DataGrid
                 Parameters);
 
             isLoading = false;
-        }
-
-        private async Task GetItemCount()
-        {
-            totalItems = null;
-            totalItems = await DataService.GetItemCountAsync(currentSearchQuery, Parameters);
         }
 
         protected async Task HandlePageChange(int page)
@@ -99,7 +88,6 @@ namespace Pyrox.BlazorComponents.DataGrid
         protected async Task Search(string query)
         {
             currentSearchQuery = query;
-            await GetItemCount();
             paginationControls.GoToPage(1);
         }
 

--- a/src/Pyrox.BlazorComponents.DataGrid/Interfaces/IDataGridService.cs
+++ b/src/Pyrox.BlazorComponents.DataGrid/Interfaces/IDataGridService.cs
@@ -1,18 +1,14 @@
-﻿using System.Collections.Generic;
+﻿using Pyrox.BlazorComponents.DataGrid.Models;
 using System.Threading.Tasks;
 
 namespace Pyrox.BlazorComponents.DataGrid.Interfaces
 {
     public interface IDataGridService<TItem>
     {
-        Task<List<TItem>> GetItemsAsync(
+        Task<DataGridResult<TItem>> GetItemsAsync(
             int pageNumber,
             int pageSize,
             SortInformation<TItem> sortInfo = null,
-            string searchQuery = null,
-            object parameters = null);
-
-        Task<int> GetItemCountAsync(
             string searchQuery = null,
             object parameters = null);
     }

--- a/src/Pyrox.BlazorComponents.DataGrid/Models/DataGridResult.cs
+++ b/src/Pyrox.BlazorComponents.DataGrid/Models/DataGridResult.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace Pyrox.BlazorComponents.DataGrid.Models
+{
+    public class DataGridResult<TItem>
+    {
+        public IEnumerable<TItem> Data { get; }
+        public uint TotalItems { get; }
+
+        public DataGridResult(IEnumerable<TItem> data, uint totalItems)
+        {
+            Data = data;
+            TotalItems = totalItems;
+        }
+    }
+}

--- a/tests/Pyrox.BlazorComponents.DataGrid.E2ETests/Data/WeatherForecastService.cs
+++ b/tests/Pyrox.BlazorComponents.DataGrid.E2ETests/Data/WeatherForecastService.cs
@@ -1,8 +1,7 @@
 using Pyrox.BlazorComponents.DataGrid.Interfaces;
+using Pyrox.BlazorComponents.DataGrid.Models;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Threading.Tasks;
 
 namespace Pyrox.BlazorComponents.DataGrid.E2ETests.Data
@@ -22,7 +21,7 @@ namespace Pyrox.BlazorComponents.DataGrid.E2ETests.Data
                 Summary = Summaries[new Random().Next(Summaries.Length)]
             }).ToArray();
 
-        public async Task<List<WeatherForecast>> GetItemsAsync(
+        public async Task<DataGridResult<WeatherForecast>> GetItemsAsync(
             int pageNumber,
             int pageSize,
             SortInformation<WeatherForecast> sortInfo = null,
@@ -91,37 +90,13 @@ namespace Pyrox.BlazorComponents.DataGrid.E2ETests.Data
                 }
             }
 
+            var totalItems = (uint)query.Count();
+
             var items = query.Skip((pageNumber - 1) * pageSize)
                 .Take(pageSize)
                 .ToList();
 
-            return items;
-        }
-
-        public async Task<int> GetItemCountAsync(
-            string searchQuery = null,
-            object parameters = null)
-        {
-            var query = Data.AsQueryable();
-            if (!(searchQuery is null))
-            {
-                var searchQueryLowercase = searchQuery.ToLower();
-                query = query.Where(f => f.Date.ToString().ToLower().Contains(searchQueryLowercase)
-                                    || f.TemperatureC.ToString().Contains(searchQuery)
-                                    || f.TemperatureF.ToString().Contains(searchQuery)
-                                    || f.Summary.ToLower().Contains(searchQueryLowercase));
-            }
-
-            if (!(parameters is null))
-            {
-                var type = parameters.GetType();
-                if (!(type.GetProperty(nameof(WeatherForecast.Summary)) is null))
-                {
-                    query = query.Where(f => f.Summary == type.GetProperty(nameof(WeatherForecast.Summary)).GetValue(parameters) as string);
-                }
-            }
-
-            return query.Count();
+            return new DataGridResult<WeatherForecast>(items, totalItems);
         }
     }
 }


### PR DESCRIPTION
This PR consolidates the items that need to be returned by `IDataGridService` and the total item count into a single class called `DataGridResult`. `IDataGridService<DataGridResult<TItem>>.GetItemsAsync` should now return a `DataGridResult` object. This object can be constructed via a constructor that takes an `IEnumerable` of `TItem` and a `uint` indicating the total number of items present.

This change was made to allow for a single class to provide implementations for `IDataGridService`s with multiple `TItem` types. Previously, this was not possible as the `GetItemCountAsync` method did not have a way of differentiating itself between type parameters. With this change, the following can be done:

```cs
public class SomeService :
    IDataGridService<SomeItem>,
    IDataGridService<SomeOtherItem>
{
    public async Task<DataGridResult<SomeItem>> GetItemsAsync(...)
    {
        // ...
    }

    public async Task<DataGridResult<SomeOtherItem>> GetItemsAsync(...)
    {
        // ...
    }
}
```

This is a breaking change as it changes the signature of the `GetItemsAsync` method of `IDataGridService`.