### PR TITLE
Add custom sort key display name attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ $ dotnet add package Pyrox.BlazorComponents.DataGrid
 
 **NOTE:** This component is built and tested with Blazor Server only. This component is not guaranteed to work with other versions of Blazor, such as Blazor WebAssembly.
 
+### General usage (with example)
+
 The instructions here are based on the weather forecast service provided in the default Blazor Server template. The code can be found in `tests/Pyrox.BlazorComponents.DataGrid.E2ETests`.
 
 Assuming we have the following `WeatherForecast` entity:
@@ -120,6 +122,25 @@ Supply the `TItem` type parameter when declaring the component.
 The following parameters are optional:
 - `DefaultSort`: Determines the default sort order for the fetched items. Use the `SortInformation<TItem>.SortAscending` or `SortInformation<TItem>.SortDescending` static methods to quickly get the `SortInformation<TItem>` instance that you want.
 - `Parameters`: Parameters that you want to filter the results by. For example, supply an `OrderId` as a parameter and only fetch order items related to that `OrderId`. You are responsible for handling the presence/absence of these parameters in your `IDataGridService` implementation.
+
+### Customise sort key display name
+
+By default, the sort dropdown gets its key names from the property names of `TItem` and converts them into title case. If you would like to provide your own sort key display name, you can use the `SortKeyDisplayName` attribute on your `TItem` class properties.
+
+```cs
+public class WeatherForecast
+{
+    public DateTime Date { get; set; }
+
+    [SortKeyDisplayName("Temperature (C)")]
+    public int TemperatureC { get; set; }
+
+    [SortKeyDisplayName("Temperature (F)")]
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+    public string Summary { get; set; }
+}
+```
 
 # Contributing
 

--- a/src/Pyrox.BlazorComponents.DataGrid/Attributes/SortKeyDisplayNameAttribute.cs
+++ b/src/Pyrox.BlazorComponents.DataGrid/Attributes/SortKeyDisplayNameAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Pyrox.BlazorComponents.DataGrid.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class SortKeyDisplayNameAttribute : Attribute
+    {
+        public string DisplayName { get; }
+
+        public SortKeyDisplayNameAttribute(string displayName)
+        {
+            DisplayName = displayName;
+        }
+    }
+}

--- a/src/Pyrox.BlazorComponents.DataGrid/DataGrid.razor
+++ b/src/Pyrox.BlazorComponents.DataGrid/DataGrid.razor
@@ -1,4 +1,5 @@
-﻿@typeparam TItem
+﻿@using Humanizer
+@typeparam TItem
 @inherits DataGridBase<TItem>
 
 <form class="form-inline mb-2">
@@ -19,13 +20,13 @@
                 if (sortInfo == currentSort)
                 {
                     <option selected value="@sortInfo.ToString()">
-                        @($"{sortInfo.Key.ToString()} ({sortInfo.Type.ToString().ToLower()})")
+                        @($"{sortInfo.Key.Humanize(LetterCasing.Title)} ({sortInfo.Type.ToString().ToLower()})")
                     </option>
                 }
                 else
                 {
                     <option value="@sortInfo.ToString()">
-                        @($"{sortInfo.Key.ToString()} ({sortInfo.Type.ToString().ToLower()})")
+                        @($"{sortInfo.Key.Humanize(LetterCasing.Title)} ({sortInfo.Type.ToString().ToLower()})")
                     </option>
                 }
             }

--- a/src/Pyrox.BlazorComponents.DataGrid/DataGrid.razor
+++ b/src/Pyrox.BlazorComponents.DataGrid/DataGrid.razor
@@ -1,4 +1,5 @@
 ﻿@using Humanizer
+@using Pyrox.BlazorComponents.DataGrid.Attributes
 @typeparam TItem
 @inherits DataGridBase<TItem>
 
@@ -17,16 +18,28 @@
         <select id="sortSelect" class="custom-select mr-sm-2" @onchange="Sort">
             @foreach (var sortInfo in SortInformation<TItem>.GetSortInformationPairs())
             {
+                var keyDisplayName = sortInfo.Key.Humanize(LetterCasing.Title);
+
+                var attributes = typeof(TItem).GetProperty(sortInfo.Key).GetCustomAttributes(true);
+                foreach (var attr in attributes)
+                {
+                    SortKeyDisplayNameAttribute displayNameAttribute = attr as SortKeyDisplayNameAttribute;
+                    if (!(displayNameAttribute is null))
+                    {
+                        keyDisplayName = displayNameAttribute.DisplayName;
+                    }
+                }
+
                 if (sortInfo == currentSort)
                 {
                     <option selected value="@sortInfo.ToString()">
-                        @($"{sortInfo.Key.Humanize(LetterCasing.Title)} ({sortInfo.Type.ToString().ToLower()})")
+                        @($"{keyDisplayName} ({sortInfo.Type.ToString().ToLower()})")
                     </option>
                 }
                 else
                 {
                     <option value="@sortInfo.ToString()">
-                        @($"{sortInfo.Key.Humanize(LetterCasing.Title)} ({sortInfo.Type.ToString().ToLower()})")
+                        @($"{keyDisplayName} ({sortInfo.Type.ToString().ToLower()})")
                     </option>
                 }
             }

--- a/src/Pyrox.BlazorComponents.DataGrid/Pyrox.BlazorComponents.DataGrid.csproj
+++ b/src/Pyrox.BlazorComponents.DataGrid/Pyrox.BlazorComponents.DataGrid.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="BlazorStrap" Version="1.0.103" />
+    <PackageReference Include="Humanizer.Core" Version="2.7.9" />
     <PackageReference Include="JW.Pager" Version="1.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.0.0" />

--- a/tests/Pyrox.BlazorComponents.DataGrid.E2ETests/Data/WeatherForecast.cs
+++ b/tests/Pyrox.BlazorComponents.DataGrid.E2ETests/Data/WeatherForecast.cs
@@ -1,3 +1,4 @@
+using Pyrox.BlazorComponents.DataGrid.Attributes;
 using System;
 
 namespace Pyrox.BlazorComponents.DataGrid.E2ETests.Data
@@ -6,8 +7,10 @@ namespace Pyrox.BlazorComponents.DataGrid.E2ETests.Data
     {
         public DateTime Date { get; set; }
 
+        [SortKeyDisplayName("Temperature (C)")]
         public int TemperatureC { get; set; }
 
+        [SortKeyDisplayName("Temperature (F)")]
         public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
 
         public string Summary { get; set; }


### PR DESCRIPTION
Added a `SortKeyDisplayName` attribute that can be used to customise the names of sort keys that are displayed in the sort dropdown. Previously, the component would only use the item class's property names without modification.

If no `SortKeyDisplayName` attribute is supplied for a property, the component will now attempt to convert the property name to title case and display the result.